### PR TITLE
Return types and doc blocks

### DIFF
--- a/src/BaseColor.php
+++ b/src/BaseColor.php
@@ -36,7 +36,7 @@ abstract class BaseColor
     abstract public function toHsl();
 
     /**
-     * @return \Ozdemirburak\Iris\Color\Hsl
+     * @return \Ozdemirburak\Iris\Color\Hsla
      */
     abstract public function toHsla();
 
@@ -51,7 +51,7 @@ abstract class BaseColor
     abstract public function toRgb();
 
     /**
-     * @return \Ozdemirburak\Iris\Color\Rgb
+     * @return \Ozdemirburak\Iris\Color\Rgba
      */
     abstract public function toRgba();
 

--- a/src/Color/Hex.php
+++ b/src/Color/Hex.php
@@ -31,7 +31,7 @@ class Hex extends BaseColor
      */
     protected function initialize($color)
     {
-        list($this->red, $this->green, $this->blue) = str_split($color, 2);
+        return list($this->red, $this->green, $this->blue) = str_split($color, 2);
     }
 
     /**
@@ -52,7 +52,7 @@ class Hex extends BaseColor
     }
 
     /**
-     * @return \Ozdemirburak\Iris\Color\Hsl
+     * @return \Ozdemirburak\Iris\Color\Hsla
      */
     public function toHsla()
     {

--- a/src/Color/Hsl.php
+++ b/src/Color/Hsl.php
@@ -16,7 +16,7 @@ class Hsl extends BaseColor
      */
     protected function initialize($color)
     {
-        list($this->hue, $this->saturation, $this->lightness) = explode(',', $color);
+        return list($this->hue, $this->saturation, $this->lightness) = explode(',', $color);
     }
 
     /**

--- a/src/Color/Hsv.php
+++ b/src/Color/Hsv.php
@@ -21,7 +21,7 @@ class Hsv extends BaseColor
      */
     protected function initialize($color)
     {
-        list($this->hue, $this->saturation, $this->value) = explode(',', $color);
+        return list($this->hue, $this->saturation, $this->value) = explode(',', $color);
     }
 
     /**
@@ -35,7 +35,7 @@ class Hsv extends BaseColor
 
     /**
      * @throws \OzdemirBurak\Iris\Exceptions\InvalidColorException
-     * @return \Ozdemirburak\Iris\Color\Hsv
+     * @return \Ozdemirburak\Iris\Color\Hsl
      */
     public function toHsl()
     {
@@ -47,7 +47,7 @@ class Hsv extends BaseColor
     }
 
     /**
-     * @return \Ozdemirburak\Iris\Color\Hsl
+     * @return \Ozdemirburak\Iris\Color\Hsla
      */
     public function toHsla()
     {

--- a/src/Color/Rgb.php
+++ b/src/Color/Rgb.php
@@ -39,7 +39,7 @@ class Rgb extends BaseColor
      */
     protected function initialize($color)
     {
-        list($this->red, $this->green, $this->blue) = explode(',', $color);
+        return list($this->red, $this->green, $this->blue) = explode(',', $color);
     }
 
     /**
@@ -81,7 +81,7 @@ class Rgb extends BaseColor
 
     /**
      * @throws \OzdemirBurak\Iris\Exceptions\InvalidColorException
-     * @return \Ozdemirburak\Iris\Color\Hsl
+     * @return \Ozdemirburak\Iris\Color\Hsv
      */
     public function toHsv()
     {

--- a/src/Color/Rgba.php
+++ b/src/Color/Rgba.php
@@ -40,7 +40,7 @@ class Rgba extends BaseColor
     /**
      * @param string $color
      *
-     * @return array
+     * @return void
      */
     protected function initialize($color)
     {
@@ -63,7 +63,7 @@ class Rgba extends BaseColor
     }
 
     /**
-     * @return \Ozdemirburak\Iris\Color\Rgb
+     * @return \Ozdemirburak\Iris\Color\Rgba
      */
     public function toRgba()
     {
@@ -87,7 +87,7 @@ class Rgba extends BaseColor
     }
 
     /**
-     * @return \Ozdemirburak\Iris\Color\Hsl
+     * @return \Ozdemirburak\Iris\Color\Hsla|float
      */
     public function toHsla()
     {
@@ -95,7 +95,7 @@ class Rgba extends BaseColor
     }
 
     /**
-     * @return \Ozdemirburak\Iris\Color\Hsl
+     * @return \Ozdemirburak\Iris\Color\Hsv
      */
     public function toHsv()
     {

--- a/src/Traits/RgbTrait.php
+++ b/src/Traits/RgbTrait.php
@@ -22,7 +22,7 @@ trait RgbTrait
     /**
      * @param int|string $red
      *
-     * @return int|string|this
+     * @return int|string|$this
      */
     public function red($red = null)
     {
@@ -36,7 +36,7 @@ trait RgbTrait
     /**
      * @param float|int|string $green
      *
-     * @return float|int|string|this
+     * @return float|int|string|$this
      */
     public function green($green = null)
     {
@@ -50,7 +50,7 @@ trait RgbTrait
     /**
      * @param float|int|string $blue
      *
-     * @return float|int|string|this
+     * @return float|int|string|$this
      */
     public function blue($blue = null)
     {

--- a/tests/Color/HexTest.php
+++ b/tests/Color/HexTest.php
@@ -48,7 +48,8 @@ class HexTest extends TestCase
         try {
             $hex = new Hex('66Z');
         } catch (InvalidColorException $e) {
-            return $this->assertContains('Invalid HEX value', $e->getMessage());
+            $this->assertContains('Invalid HEX value', $e->getMessage());
+            return;
         }
         $this->fail('Exception has not been raised.');
     }

--- a/tests/Color/HslTest.php
+++ b/tests/Color/HslTest.php
@@ -39,7 +39,8 @@ class HslTest extends TestCase
         try {
             $hsl = new Hsl('333,0,666');
         } catch (InvalidColorException $e) {
-            return $this->assertContains('Invalid HSL value', $e->getMessage());
+            $this->assertContains('Invalid HSL value', $e->getMessage());
+            return;
         }
         $this->fail('Exception has not been raised.');
     }

--- a/tests/Color/HsvTest.php
+++ b/tests/Color/HsvTest.php
@@ -39,7 +39,8 @@ class HsvTest extends TestCase
         try {
             $hsv = new Hsv('333,0,666');
         } catch (InvalidColorException $e) {
-            return $this->assertContains('Invalid HSV value', $e->getMessage());
+            $this->assertContains('Invalid HSV value', $e->getMessage());
+            return;
         }
         $this->fail('Exception has not been raised.');
     }

--- a/tests/Color/RgbTest.php
+++ b/tests/Color/RgbTest.php
@@ -39,7 +39,8 @@ class RgbTest extends TestCase
         try {
             $rgb = new Rgb('333,0,666');
         } catch (InvalidColorException $e) {
-            return $this->assertContains('Invalid RGB value', $e->getMessage());
+            $this->assertContains('Invalid RGB value', $e->getMessage());
+            return;
         }
         $this->fail('Exception has not been raised.');
     }


### PR DESCRIPTION
This fixes IDE warnings about incorrect return types. Pre-work for writing tests