### PR TITLE
Added isLight() and isDark() support

### DIFF
--- a/src/BaseColor.php
+++ b/src/BaseColor.php
@@ -147,6 +147,25 @@ abstract class BaseColor
     }
 
     /**
+     * @link https://en.wikipedia.org/wiki/Luma_(video) Magic numbers taken from link
+     * @return boolean
+     */
+    public function isLight()
+    {
+        $color = $this->toRgb();
+        $darkness = 1 - (0.299 * $color->red() + 0.587 * $color->green() + 0.114 * $color->blue()) / 255;
+        return $darkness < 0.5;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isDark()
+    {
+        return !$this->isLight();
+    }
+
+    /**
      * @param int $percent
      *
      * @return mixed

--- a/tests/OperationsTest.php
+++ b/tests/OperationsTest.php
@@ -47,4 +47,27 @@ class OperationsTest extends TestCase
         $this->assertEquals(new Hex('#808080'), (new Hex('#000'))->mix(new Hex('#fff')));
         $this->assertEquals(new Hex('#ff8000'), (new Hex('#ff0000'))->mix(new Hex('#ffff00')));
     }
+
+    /**
+     * @group operations-is-light
+     */
+    public function testIsLight()
+    {
+        $this->assertFalse((new Hex('#000000'))->isLight());
+        $this->assertTrue((new Hex('#ffffff'))->isLight());
+        $this->assertTrue((new Hex('#808080'))->isLight());
+        $this->assertTrue((new Hex('#888888'))->isLight());
+        $this->assertFalse((new Hex('#777777'))->isLight());
+        $this->assertFalse((new Hex('#ff0000'))->isLight());
+        $this->assertTrue((new Hex('#ffff00'))->isLight());
+    }
+
+    /**
+     * @group operations-is-dark
+     */
+    public function testIsDark()
+    {
+        $this->assertTrue((new Hex('#000000'))->isDark());
+        $this->assertFalse((new Hex('#ffffff'))->isDark());
+    }
 }


### PR DESCRIPTION
Would be great to add those two helpful methods to determine if a certain color is light or dark. The magic numbers are taken from [Wikipedia](https://en.wikipedia.org/wiki/Luma_(video)#Rec._601_luma_versus_Rec._709_luma_coefficients).