### PR TITLE
fix docblocks namespace casing

### DIFF
--- a/src/BaseColor.php
+++ b/src/BaseColor.php
@@ -26,32 +26,32 @@ abstract class BaseColor
     abstract public function values();
 
     /**
-     * @return \Ozdemirburak\Iris\Color\Hex
+     * @return \OzdemirBurak\Iris\Color\Hex
      */
     abstract public function toHex();
 
     /**
-     * @return \Ozdemirburak\Iris\Color\Hsl
+     * @return \OzdemirBurak\Iris\Color\Hsl
      */
     abstract public function toHsl();
 
     /**
-     * @return \Ozdemirburak\Iris\Color\Hsla
+     * @return \OzdemirBurak\Iris\Color\Hsla
      */
     abstract public function toHsla();
 
     /**
-     * @return \Ozdemirburak\Iris\Color\Hsv
+     * @return \OzdemirBurak\Iris\Color\Hsv
      */
     abstract public function toHsv();
 
     /**
-     * @return \Ozdemirburak\Iris\Color\Rgb
+     * @return \OzdemirBurak\Iris\Color\Rgb
      */
     abstract public function toRgb();
 
     /**
-     * @return \Ozdemirburak\Iris\Color\Rgba
+     * @return \OzdemirBurak\Iris\Color\Rgba
      */
     abstract public function toRgba();
 
@@ -231,7 +231,7 @@ abstract class BaseColor
     /**
      * @param \OzdemirBurak\Iris\BaseColor $color
      *
-     * @return $this|\Ozdemirburak\Iris\Color\Hex|\Ozdemirburak\Iris\Color\Hsl|\Ozdemirburak\Iris\Color\Hsv|\Ozdemirburak\Iris\Color\Rgb
+     * @return $this|\OzdemirBurak\Iris\Color\Hex|\OzdemirBurak\Iris\Color\Hsl|\OzdemirBurak\Iris\Color\Hsv|\OzdemirBurak\Iris\Color\Rgb
      */
     protected function back(BaseColor $color)
     {

--- a/src/Color/Hex.php
+++ b/src/Color/Hex.php
@@ -44,7 +44,7 @@ class Hex extends BaseColor
 
     /**
      * @throws \OzdemirBurak\Iris\Exceptions\InvalidColorException
-     * @return \Ozdemirburak\Iris\Color\Hsl
+     * @return \OzdemirBurak\Iris\Color\Hsl
      */
     public function toHsl()
     {
@@ -53,7 +53,7 @@ class Hex extends BaseColor
 
     /**
      * @throws \OzdemirBurak\Iris\Exceptions\InvalidColorException
-     * @return \Ozdemirburak\Iris\Color\Hsla
+     * @return \OzdemirBurak\Iris\Color\Hsla
      */
     public function toHsla()
     {
@@ -62,7 +62,7 @@ class Hex extends BaseColor
 
     /**
      * @throws \OzdemirBurak\Iris\Exceptions\InvalidColorException
-     * @return \Ozdemirburak\Iris\Color\Hsv
+     * @return \OzdemirBurak\Iris\Color\Hsv
      */
     public function toHsv()
     {
@@ -71,7 +71,7 @@ class Hex extends BaseColor
 
     /**
      * @throws \OzdemirBurak\Iris\Exceptions\InvalidColorException
-     * @return \Ozdemirburak\Iris\Color\Rgb
+     * @return \OzdemirBurak\Iris\Color\Rgb
      */
     public function toRgb()
     {

--- a/src/Color/Hsl.php
+++ b/src/Color/Hsl.php
@@ -37,7 +37,7 @@ class Hsl extends BaseColor
     }
 
     /**
-     * @return \Ozdemirburak\Iris\Color\Hsl
+     * @return \OzdemirBurak\Iris\Color\Hsl
      */
     public function toHsl()
     {
@@ -55,7 +55,7 @@ class Hsl extends BaseColor
 
     /**
      * @throws \OzdemirBurak\Iris\Exceptions\InvalidColorException
-     * @return \Ozdemirburak\Iris\Color\Hsv
+     * @return \OzdemirBurak\Iris\Color\Hsv
      */
     public function toHsv()
     {
@@ -69,7 +69,7 @@ class Hsl extends BaseColor
 
     /**
      * @throws \OzdemirBurak\Iris\Exceptions\InvalidColorException
-     * @return \Ozdemirburak\Iris\Color\Rgb
+     * @return \OzdemirBurak\Iris\Color\Rgb
      */
     public function toRgb()
     {

--- a/src/Color/Hsla.php
+++ b/src/Color/Hsla.php
@@ -54,7 +54,7 @@ class Hsla extends BaseColor
 
     /**
      * @throws \OzdemirBurak\Iris\Exceptions\InvalidColorException
-     * @return \Ozdemirburak\Iris\Color\Hsl
+     * @return \OzdemirBurak\Iris\Color\Hsl
      */
     public function toHsl()
     {
@@ -63,7 +63,7 @@ class Hsla extends BaseColor
 
     /**
      * @throws \OzdemirBurak\Iris\Exceptions\InvalidColorException
-     * @return \Ozdemirburak\Iris\Color\Rgba
+     * @return \OzdemirBurak\Iris\Color\Rgba
      */
     public function toRgba()
     {
@@ -72,7 +72,7 @@ class Hsla extends BaseColor
 
     /**
      * @throws \OzdemirBurak\Iris\Exceptions\InvalidColorException
-     * @return \Ozdemirburak\Iris\Color\Rgb
+     * @return \OzdemirBurak\Iris\Color\Rgb
      */
     public function toRgb()
     {
@@ -80,7 +80,7 @@ class Hsla extends BaseColor
     }
 
     /**
-     * @return \Ozdemirburak\Iris\Color\Hsla
+     * @return \OzdemirBurak\Iris\Color\Hsla
      */
     public function toHsla()
     {
@@ -89,7 +89,7 @@ class Hsla extends BaseColor
 
     /**
      * @throws \OzdemirBurak\Iris\Exceptions\InvalidColorException
-     * @return \Ozdemirburak\Iris\Color\Hsv
+     * @return \OzdemirBurak\Iris\Color\Hsv
      */
     public function toHsv()
     {
@@ -98,7 +98,7 @@ class Hsla extends BaseColor
 
     /**
      * @throws \OzdemirBurak\Iris\Exceptions\InvalidColorException
-     * @return \Ozdemirburak\Iris\Color\Hex
+     * @return \OzdemirBurak\Iris\Color\Hex
      */
     public function toHex()
     {

--- a/src/Color/Hsv.php
+++ b/src/Color/Hsv.php
@@ -43,7 +43,7 @@ class Hsv extends BaseColor
 
     /**
      * @throws \OzdemirBurak\Iris\Exceptions\InvalidColorException
-     * @return \Ozdemirburak\Iris\Color\Hsl
+     * @return \OzdemirBurak\Iris\Color\Hsl
      */
     public function toHsl()
     {
@@ -56,7 +56,7 @@ class Hsv extends BaseColor
 
     /**
      * @throws \OzdemirBurak\Iris\Exceptions\InvalidColorException
-     * @return \Ozdemirburak\Iris\Color\Hsla
+     * @return \OzdemirBurak\Iris\Color\Hsla
      */
     public function toHsla()
     {
@@ -64,7 +64,7 @@ class Hsv extends BaseColor
     }
 
     /**
-     * @return \Ozdemirburak\Iris\Color\Hsv
+     * @return \OzdemirBurak\Iris\Color\Hsv
      */
     public function toHsv()
     {
@@ -73,7 +73,7 @@ class Hsv extends BaseColor
 
     /**
      * @throws \OzdemirBurak\Iris\Exceptions\InvalidColorException
-     * @return \Ozdemirburak\Iris\Color\Rgb
+     * @return \OzdemirBurak\Iris\Color\Rgb
      */
     public function toRgb()
     {
@@ -109,7 +109,7 @@ class Hsv extends BaseColor
 
     /**
      * @throws \OzdemirBurak\Iris\Exceptions\InvalidColorException
-     * @return \Ozdemirburak\Iris\Color\Rgba
+     * @return \OzdemirBurak\Iris\Color\Rgba
      */
     public function toRgba()
     {

--- a/src/Color/Rgb.php
+++ b/src/Color/Rgb.php
@@ -54,7 +54,7 @@ class Rgb extends BaseColor
 
     /**
      * @throws \OzdemirBurak\Iris\Exceptions\InvalidColorException
-     * @return \Ozdemirburak\Iris\Color\Hsl
+     * @return \OzdemirBurak\Iris\Color\Hsl
      */
     public function toHsl()
     {
@@ -82,7 +82,7 @@ class Rgb extends BaseColor
 
     /**
      * @throws \OzdemirBurak\Iris\Exceptions\InvalidColorException
-     * @return \Ozdemirburak\Iris\Color\Hsv
+     * @return \OzdemirBurak\Iris\Color\Hsv
      */
     public function toHsv()
     {
@@ -96,7 +96,7 @@ class Rgb extends BaseColor
     }
 
     /**
-     * @return \Ozdemirburak\Iris\Color\Rgb
+     * @return \OzdemirBurak\Iris\Color\Rgb
      */
     public function toRgb()
     {

--- a/src/Color/Rgba.php
+++ b/src/Color/Rgba.php
@@ -77,7 +77,7 @@ class Rgba extends BaseColor
     }
 
     /**
-     * @return \Ozdemirburak\Iris\Color\Rgba
+     * @return \OzdemirBurak\Iris\Color\Rgba
      */
     public function toRgba()
     {
@@ -95,7 +95,7 @@ class Rgba extends BaseColor
 
     /**
      * @throws \OzdemirBurak\Iris\Exceptions\InvalidColorException
-     * @return \Ozdemirburak\Iris\Color\Hsl
+     * @return \OzdemirBurak\Iris\Color\Hsl
      */
     public function toHsl()
     {
@@ -104,7 +104,7 @@ class Rgba extends BaseColor
 
     /**
      * @throws \OzdemirBurak\Iris\Exceptions\InvalidColorException
-     * @return \Ozdemirburak\Iris\Color\Hsla|float
+     * @return \OzdemirBurak\Iris\Color\Hsla|float
      */
     public function toHsla()
     {
@@ -113,7 +113,7 @@ class Rgba extends BaseColor
 
     /**
      * @throws \OzdemirBurak\Iris\Exceptions\InvalidColorException
-     * @return \Ozdemirburak\Iris\Color\Hsv
+     * @return \OzdemirBurak\Iris\Color\Hsv
      */
     public function toHsv()
     {

--- a/src/Traits/HslTrait.php
+++ b/src/Traits/HslTrait.php
@@ -29,7 +29,7 @@ trait HslTrait
 
     /**
      * @throws \OzdemirBurak\Iris\Exceptions\InvalidColorException
-     * @return \Ozdemirburak\Iris\Color\Rgb
+     * @return \OzdemirBurak\Iris\Color\Rgb
      */
     public function convertToRgb()
     {


### PR DESCRIPTION
Hi, thank you for your library! I fixed the library namespace casing in docblocks. I used vimeo/psalm for statistical analysis and the analyzer found this typo.