### PR TITLE
Fix/alpha allow1.0

### DIFF
--- a/src/Traits/AlphaTrait.php
+++ b/src/Traits/AlphaTrait.php
@@ -28,7 +28,7 @@ trait AlphaTrait
      */
     protected function validationRules()
     {
-        return '/^(\d{1,3}),(\d{1,3}),(\d{1,3}),(\d\.\d{1,})$/';
+        return '/^(\d{1,3}),(\d{1,3}),(\d{1,3}),(\d\.\d{1,2})$/';
     }
 
     /**
@@ -40,6 +40,7 @@ trait AlphaTrait
     {
         if (strpos($color, ',') !== false) {
             $parts = explode(',', $color);
+            $parts[3] = round($parts[3], 2);
             $parts[3] = strpos($parts[3], '.') === false ? $parts[3] . '.0' : $parts[3];
             $color = implode(',', $parts);
         }


### PR DESCRIPTION
I should have run the tests with the last PR.
I'm sorry for this problem.

Basically what happened is, that an alpha of 1.0 will be rounded to 1 therefore the check throws an error and no . is in the alpha value.

This will fix I also have run the Tests and included them in my Project.