### PR TITLE
Add ->fadeIn and ->fadeOut

### DIFF
--- a/src/BaseColor.php
+++ b/src/BaseColor.php
@@ -233,6 +233,35 @@ abstract class BaseColor
      }
 
     /**
+     * @param number $percent
+     *
+     * @return OzdemirBurak\Iris\Color\Rgba|\OzdemirBurak\Iris\Color\Hsla;
+     */
+     public function fadeIn($percent)
+     {
+         $percent = $percent / 100;
+         if ($this instanceof \OzdemirBurak\Iris\Color\Hsla || $this instanceof \OzdemirBurak\Iris\Color\Rgba) {
+             return $this->alpha($this->clamp($this->alpha() + $percent));
+         } elseif ($this instanceof \OzdemirBurak\Iris\Color\Hsl) {
+             $hsla = $this->toHsla();
+             return $hsla->alpha($this->clamp($hsla->alpha() + $percent));
+         }
+         $rgba = $this->toRgba();
+         return $rgba->alpha($this->clamp($rgba->alpha() + $percent));
+     }
+
+    /**
+     * @param number $percent
+     *
+     * @return OzdemirBurak\Iris\Color\Rgba|\OzdemirBurak\Iris\Color\Hsla;
+     */
+     public function fadeOut($percent)
+     {
+         return $this->fadeIn(-1 * $percent);
+     }
+
+
+    /**
      * @param $value
      *
      * @return float

--- a/tests/OperationsTest.php
+++ b/tests/OperationsTest.php
@@ -93,11 +93,29 @@ class OperationsTest extends TestCase
     }
 
     /**
-     * @group operations-shade
+     * @group operations-fade
      */
      public function testFade()
      {
         $this->assertEquals(new Hsla('90,90,50,0.1'), (new Hsl('90,90,50'))->fade(10));
         $this->assertEquals(new Rgba('128,242,13,0.1'), (new Rgb('128,242,13'))->fade(10));
+     }
+
+    /**
+     * @group operations-fadeIn
+     */
+     public function testFadeIn()
+     {
+        $this->assertEquals(new Hsla('90,90,50,0.4'), (new Hsla('90,90,50,0.3'))->fadeIn(10));
+        $this->assertEquals(new Rgba('128,242,13,0.4'), (new Rgba('128,242,13,0.3'))->fadeIn(10));
+     }
+
+    /**
+     * @group operations-fadeOut
+     */
+     public function testFadeOut()
+     {
+        $this->assertEquals(new Hsla('90,90,50,0.2'), (new Hsla('90,90,50,0.3'))->fadeOut(10));
+        $this->assertEquals(new Rgba('128,242,13,0.2'), (new Rgba('128,242,13,0.3'))->fadeOut(10));
      }
 }


### PR DESCRIPTION
For Issue #23 for Hacktoberfest. I added tests as well - let me know what you think.

As a tangent, I'd suggest that all the ->alpha() functions should work off of numbers from 0 to 1 instead of treating them as percentages, and maybe have a second set of functions for percentages? I think CSS always uses 0-1 values for hsla() and rgba() colors.