### PR TITLE
Added new 'Hexa' class to support hex+alpha values

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,32 @@ echo $hex->red(); // ff
 echo $hex->green(); // 00
 echo $hex->blue(); // ff
 echo $hex->values(); // ['ff', '00', 'ff']
+$hexa = $hex->toHexa(); // \OzdemirBurak\Iris\Color\Hexa('ff00ffff')
 $hsl = $hex->toHsl(); // \OzdemirBurak\Iris\Color\Hsl('300,100,50')
 $hsla = $hex->toHsla(); // \OzdemirBurak\Iris\Color\Hsla('300,100,50,1.0')
 $hsv = $hex->toHsv(); // \OzdemirBurak\Iris\Color\Hsv('300,100,100')
 $rgb = $hex->toRgb(); // \OzdemirBurak\Iris\Color\Rgb('255,0,255')
 $rgba = $hex->toRgba(); // \OzdemirBurak\Iris\Color\Rgba('255,0,255,1.0')
 echo $hex; // #ff00ff
+```
+
+### Hexa (hex with alpha value)
+
+``` php
+use OzdemirBurak\Iris\Color\Hexa;
+
+$hexa = new Hexa('#ff00ff4c');
+echo $hexa->red(); // ff
+echo $hexa->green(); // 00
+echo $hexa->blue(); // ff
+echo $hexa->alpha(); // 0.3 - as a float for compatibility with the other conversions
+echo $hexa->values(); // ['ff', '00', 'ff', 0.3]
+$hsl = $hexa->toHsl(); // \OzdemirBurak\Iris\Color\Hsl('300,100,50')
+$hsla = $hexa->toHsla(); // \OzdemirBurak\Iris\Color\Hsla('300,100,50,0.3')
+$hsv = $hexa->toHsv(); // \OzdemirBurak\Iris\Color\Hsv('300,100,100')
+$rgb = $hexa->toRgb(); // \OzdemirBurak\Iris\Color\Rgb('255,0,255')
+$rgba = $hexa->toRgba(); // \OzdemirBurak\Iris\Color\Rgba('255,0,255,0.3')
+echo $hexa; // #ff00ff4c
 ```
 
 ### HSL
@@ -49,6 +69,7 @@ echo $hsl->lightness(); // 50
 $values = $hsl->values(); // [300, '100%', '50%']
 $normalizedValues = $hsl->valuesInUnitInterval(); // [300/360, 100/100, 50/100]
 $hex = $hsl->toHex(); // \OzdemirBurak\Iris\Color\Hex('ff00ff')
+$hexa = $hsl->toHexa(); // \OzdemirBurak\Iris\Color\Hexa('ff00ffff')
 $hsv = $hsl->toHsv(); // \OzdemirBurak\Iris\Color\Hsv('300,100,100')
 $rgb = $hsl->toRgb(); // \OzdemirBurak\Iris\Color\Rgb('255,0,255')
 $rgba = $hsl->toRgba(); // \OzdemirBurak\Iris\Color\Rgba('255,0,255,1.0')
@@ -68,6 +89,7 @@ echo $hsla->alpha(); // 0.3
 $values = $hsla->values(); // [150, '100%', '50%', 0.3]
 $hex = $hsla->toHex(); // \OzdemirBurak\Iris\Color\Hex('b2ffd8')
 $hex = $hsla->toRgba(); // \OzdemirBurak\Iris\Color\Rgba('0,255,128,0.3')
+$hexa = $hsla->toHexa(); // \OzdemirBurak\Iris\Color\Hexa('ff00ff4c')
 echo $hsla; // hsla(150,100%,50%,0.3)
 ```
 
@@ -83,6 +105,7 @@ echo $hsv->value(); // 100
 $values = $hsv->values(); // [100, '100%', '100%']
 $normalizedValues = $hsv->valuesInUnitInterval(); // [300/360, 100/100, 100/100]
 $hex = $hsv->toHex(); // \OzdemirBurak\Iris\Color\Hex('ff00ff')
+$hexa = $hsv->toHexa(); // \OzdemirBurak\Iris\Color\Hexa('ff00ffff')
 $hsl = $hsv->toHsl(); // \OzdemirBurak\Iris\Color\Hsl('300,100,50')
 $hsla = $hsv->toHsla(); // \OzdemirBurak\Iris\Color\Hsla('300,100,50,1.0')
 $hsv = $hsv->toHsv(); // \OzdemirBurak\Iris\Color\Hsv('300,100,100')
@@ -103,6 +126,7 @@ echo $rgb->green(); // 0
 echo $rgb->blue(); // 255
 $values = $rgb->values(); // [255, 0, 255]
 $hex = $rgb->toHex(); // \OzdemirBurak\Iris\Color\Hex('ff00ff')
+$hexa = $rgb->toHexa(); // \OzdemirBurak\Iris\Color\Hexa('ff00ffff')
 $hsl = $rgb->toHsl(); // \OzdemirBurak\Iris\Color\Hsl('300,100,50')
 $hsla = $rgb->toHsla(); // \OzdemirBurak\Iris\Color\Hsla('300,100,50,1.0')
 $hsv = $rgb->toHsv(); // \OzdemirBurak\Iris\Color\Hsv('300,100,100')
@@ -123,6 +147,7 @@ echo $rgba->green(); // 111
 echo $rgba->blue(); // 222
 echo $rgba->alpha(); // 0.33,
 $hex = $rgba->background((new Hex('ccc'))->toRgb())->toHex(); // \OzdemirBurak\Iris\Color\Hex('a7add1')
+$hexa = $rgba->toHexa(); // \OzdemirBurak\Iris\Color\Hexa('a7add154')
 echo $rgba; // rgba(127,127,127,0.5)
 ```
 

--- a/src/Color/Factory.php
+++ b/src/Color/Factory.php
@@ -10,12 +10,15 @@ class Factory
     {
         $color = str_replace(' ', '', $color);
         // Definitive types
-        if (preg_match('/^(?P<type>(rgba?|hsla?|hsv|#))/i', $color, $match)) {
-            $class = ucfirst(strtolower($match['type'] === '#' ? 'hex' : $match['type']));
+        if (preg_match('/^(?P<type>(rgba?|hsla?|hsv))/i', $color, $match)) {
+            $class = ucfirst(strtolower($match['type']));
             $class = 'OzdemirBurak\\Iris\\Color\\' . $class;
             return new $class($color);
         }
         // Best guess
+        if (preg_match('/^#?[a-f0-9]{8}$/i', $color)) {
+            return new Hexa($color);
+        }
         if (preg_match('/^#?[a-f0-9]{3}([a-f0-9]{3})?$/i', $color)) {
             return new Hex($color);
         }

--- a/src/Color/Hsl.php
+++ b/src/Color/Hsl.php
@@ -37,6 +37,15 @@ class Hsl extends BaseColor
     }
 
     /**
+     * @throws \OzdemirBurak\Iris\Exceptions\InvalidColorException
+     * @return \OzdemirBurak\Iris\Color\Hexa
+     */
+    public function toHexa()
+    {
+        return $this->toHex()->toHexa();
+    }
+
+    /**
      * @return \OzdemirBurak\Iris\Color\Hsl
      */
     public function toHsl()

--- a/src/Color/Hsla.php
+++ b/src/Color/Hsla.php
@@ -106,6 +106,15 @@ class Hsla extends BaseColor
     }
 
     /**
+     * @throws \OzdemirBurak\Iris\Exceptions\InvalidColorException
+     * @return \OzdemirBurak\Iris\Color\Hexa
+     */
+    public function toHexa()
+    {
+        return $this->toHex()->toHexa()->alpha($this->alpha());
+    }
+
+    /**
      * @return string
      */
     public function __toString()

--- a/src/Color/Hsv.php
+++ b/src/Color/Hsv.php
@@ -42,6 +42,15 @@ class Hsv extends BaseColor
     }
 
     /**
+     * @throws \OzdemirBurak\Iris\Exceptions\InvalidColorException
+     * @return \OzdemirBurak\Iris\Color\Hexa
+     */
+    public function toHexa()
+    {
+        return $this->toRgb()->toHex()->toHexa();
+    }
+
+    /**
      * Source: https://en.wikipedia.org/wiki/HSL_and_HSV#Interconversion
      *
      * @throws \OzdemirBurak\Iris\Exceptions\InvalidColorException

--- a/src/Color/Rgb.php
+++ b/src/Color/Rgb.php
@@ -54,6 +54,15 @@ class Rgb extends BaseColor
 
     /**
      * @throws \OzdemirBurak\Iris\Exceptions\InvalidColorException
+     * @return \OzdemirBurak\Iris\Color\Hexa
+     */
+    public function toHexa()
+    {
+        return $this->toHex()->toHexa();
+    }
+
+    /**
+     * @throws \OzdemirBurak\Iris\Exceptions\InvalidColorException
      * @return \OzdemirBurak\Iris\Color\Hsl
      */
     public function toHsl()

--- a/src/Color/Rgba.php
+++ b/src/Color/Rgba.php
@@ -96,6 +96,15 @@ class Rgba extends BaseColor
 
     /**
      * @throws \OzdemirBurak\Iris\Exceptions\InvalidColorException
+     * @return \OzdemirBurak\Iris\Color\Hexa
+     */
+    public function toHexa()
+    {
+        return $this->toRgb()->toHex()->toHexa()->alpha($this->alpha());
+    }
+
+    /**
+     * @throws \OzdemirBurak\Iris\Exceptions\InvalidColorException
      * @return \OzdemirBurak\Iris\Color\Hsl
      */
     public function toHsl()

--- a/src/Traits/AlphaTrait.php
+++ b/src/Traits/AlphaTrait.php
@@ -45,4 +45,22 @@ trait AlphaTrait
         }
         return $color;
     }
+
+    /**
+     * @param string $alpha
+     * @return float
+     */
+    protected function alphaHexToFloat(string $alpha): float
+    {
+        return sprintf('%0.2f', hexdec($alpha) / 255);
+    }
+
+    /**
+     * @param float $alpha
+     * @return string
+     */
+    protected function alphaFloatToHex(float $alpha): string
+    {
+        return dechex($alpha * 255);
+    }
 }

--- a/tests/Color/HexTest.php
+++ b/tests/Color/HexTest.php
@@ -3,6 +3,7 @@
 namespace OzdemirBurak\Iris\Tests\Color;
 
 use OzdemirBurak\Iris\Color\Hex;
+use OzdemirBurak\Iris\Color\Hexa;
 use OzdemirBurak\Iris\Color\Hsl;
 use OzdemirBurak\Iris\Color\Hsla;
 use OzdemirBurak\Iris\Color\Hsv;
@@ -60,6 +61,7 @@ class HexTest extends TestCase
         $this->assertEquals('#ff00ff', $hex);
         $this->assertEquals(['ff', '00', 'ff'], $hex->values());
         $this->assertEquals(new Hex('ff00ff'), $hex->toHex());
+        $this->assertEquals(new Hexa('ff00ffff'), $hex->toHexa());
         $this->assertEquals(new Hsl('300,100,50'), $hex->toHsl());
         $this->assertEquals(new Hsla('300,100,50,1.0'), $hex->toHsla());
         $this->assertEquals(new Hsv('300,100,100'), $hex->toHsv());

--- a/tests/Color/HexaTest.php
+++ b/tests/Color/HexaTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace OzdemirBurak\Iris\Tests\Color;
+
+use OzdemirBurak\Iris\Color\Hex;
+use OzdemirBurak\Iris\Color\Hexa;
+use OzdemirBurak\Iris\Color\Hsl;
+use OzdemirBurak\Iris\Color\Hsla;
+use OzdemirBurak\Iris\Color\Hsv;
+use OzdemirBurak\Iris\Color\Rgb;
+use OzdemirBurak\Iris\Color\Rgba;
+use PHPUnit\Framework\TestCase;
+
+class HexaTest extends TestCase
+{
+    /**
+     * @group hexa-construction
+     */
+    public function testDigitString()
+    {
+        $hexa = new Hexa('#ff00ff99');
+        $this->validateNonAlpha($hexa);
+        $this->validateAlpha($hexa, '99', 0.6);
+    }
+
+    /**
+     * @group hexa-construction
+     */
+    public function testPredefinedString()
+    {
+        $hexa = new Hexa('FUCHSIA');
+        $this->validateNonAlpha($hexa);
+        $this->validateAlpha($hexa, 'ff', 1);
+    }
+
+    /**
+     * @group hex-construction
+     */
+    public function testInvalidColor()
+    {
+        $this->expectException(\OzdemirBurak\Iris\Exceptions\InvalidColorException::class);
+        $this->expectExceptionMessage('Invalid HEXA value');
+        new Hexa('6F87DEZ');
+    }
+
+    /**
+     * @param \OzdemirBurak\Iris\Color\Hexa $hexa
+     */
+    private function validateNonAlpha(Hexa $hexa)
+    {
+        $this->assertEquals('ff', $hexa->red());
+        $this->assertEquals('00', $hexa->green());
+        $this->assertEquals('ff', $hexa->blue());
+        $this->assertEquals(new Hex('ff00ff'), $hexa->toHex());
+        $this->assertEquals(new Hsl('300,100,50'), $hexa->toHsl());
+        $this->assertEquals(new Hsv('300,100,100'), $hexa->toHsv());
+        $this->assertEquals(new Rgb('255,0,255'), $hexa->toRgb());
+    }
+
+    /**
+     * @param Hexa $hexa
+     * @param string $expectedAlphaHex
+     * @param float $expectedAlphaFloat
+     * @throws \OzdemirBurak\Iris\Exceptions\InvalidColorException
+     */
+    private function validateAlpha(Hexa $hexa, string $expectedAlphaHex, float $expectedAlphaFloat)
+    {
+        $this->assertEquals($expectedAlphaFloat, $hexa->alpha());
+        $this->assertEquals("#ff00ff{$expectedAlphaHex}", (string)$hexa);
+        $this->assertEquals(['ff', '00', 'ff', $expectedAlphaFloat], $hexa->values());
+        $this->assertEquals(new Rgba("255,0,255,{$expectedAlphaFloat}"), $hexa->toRgba());
+        $this->assertEquals(new Hsla("300,100,50,{$expectedAlphaFloat}"), $hexa->toHsla());
+    }
+}

--- a/tests/Color/HslTest.php
+++ b/tests/Color/HslTest.php
@@ -3,6 +3,7 @@
 namespace OzdemirBurak\Iris\Tests\Color;
 
 use OzdemirBurak\Iris\Color\Hex;
+use OzdemirBurak\Iris\Color\Hexa;
 use OzdemirBurak\Iris\Color\Hsl;
 use OzdemirBurak\Iris\Color\Hsla;
 use OzdemirBurak\Iris\Color\Hsv;
@@ -62,6 +63,7 @@ class HslTest extends TestCase
         $this->assertEquals([300/360, 100/100, 50/100], $hsl->valuesInUnitInterval());
         $this->assertEquals('hsl(300,100%,50%)', $hsl);
         $this->assertEquals(new Hex('ff00ff'), $hsl->toHex());
+        $this->assertEquals(new Hexa('ff00ffff'), $hsl->toHexa());
         $this->assertEquals(new Hsl('300,100,50'), $hsl->toHsl());
         $this->assertEquals(new Hsla('300,100,50,1.0'), $hsl->toHsla());
         $this->assertEquals(new Hsv('300,100,100'), $hsl->toHsv());

--- a/tests/Color/HslaTest.php
+++ b/tests/Color/HslaTest.php
@@ -4,6 +4,7 @@
 namespace OzdemirBurak\Iris\Tests\Color;
 
 use OzdemirBurak\Iris\Color\Hex;
+use OzdemirBurak\Iris\Color\Hexa;
 use OzdemirBurak\Iris\Color\Hsl;
 use OzdemirBurak\Iris\Color\Hsla;
 use OzdemirBurak\Iris\Color\Hsv;
@@ -79,6 +80,7 @@ class HslaTest extends TestCase
         $hsla = new Hsla('hsla(150,100%,50%,0.3)');
         $this->assertEquals(new Hex('b2ffd8'), $hsla->toHex());
         $this->assertEquals(new Rgba('0,255,128,0.3'), $hsla->toRgba());
+        $this->assertEquals(new Hexa('b2ffd84c'), $hsla->toHexa());
     }
 
 
@@ -88,6 +90,7 @@ class HslaTest extends TestCase
     private function validateFuchsia(Hsla $hsla)
     {
         $this->assertEquals(new Hex('ff00ff'), $hsla->toHex());
+        $this->assertEquals(new Hexa('ff00ffff'), $hsla->toHexa());
         $this->assertEquals(new Hsl('300,100,50'), $hsla->toHsl());
         $this->assertEquals(new Hsla('300,100,50,1.0'), $hsla->toHsla());
         $this->assertEquals(new Hsv('300,100,100'), $hsla->toHsv());

--- a/tests/Color/HsvTest.php
+++ b/tests/Color/HsvTest.php
@@ -3,6 +3,7 @@
 namespace OzdemirBurak\Iris\Tests\Color;
 
 use OzdemirBurak\Iris\Color\Hex;
+use OzdemirBurak\Iris\Color\Hexa;
 use OzdemirBurak\Iris\Color\Hsl;
 use OzdemirBurak\Iris\Color\Hsla;
 use OzdemirBurak\Iris\Color\Hsv;
@@ -97,6 +98,7 @@ class HsvTest extends TestCase
         $this->assertEquals([300/360, 100/100, 100/100], $hsv->valuesInUnitInterval());
         $this->assertEquals('hsv(300,100%,100%)', $hsv);
         $this->assertEquals(new Hex('ff00ff'), $hsv->toHex());
+        $this->assertEquals(new Hexa('ff00ffff'), $hsv->toHexa());
         $this->assertEquals(new Hsl('300,100,50'), $hsv->toHsl());
         $this->assertEquals(new Hsla('300,100,50,1.0'), $hsv->toHsla());
         $this->assertEquals(new Hsv('300,100,100'), $hsv->toHsv());

--- a/tests/Color/RgbTest.php
+++ b/tests/Color/RgbTest.php
@@ -3,6 +3,7 @@
 namespace OzdemirBurak\Iris\Tests\Color;
 
 use OzdemirBurak\Iris\Color\Hex;
+use OzdemirBurak\Iris\Color\Hexa;
 use OzdemirBurak\Iris\Color\Hsl;
 use OzdemirBurak\Iris\Color\Hsla;
 use OzdemirBurak\Iris\Color\Hsv;
@@ -62,6 +63,7 @@ class RgbTest extends TestCase
         $this->assertEquals([255, 0, 255], $rgb->values());
         $this->assertEquals('rgb(255,0,255)', $rgb);
         $this->assertEquals(new Hex('ff00ff'), $rgb->toHex());
+        $this->assertEquals(new Hexa('ff00ffff'), $rgb->toHexa());
         $this->assertEquals(new Hsl('300,100,50'), $rgb->toHsl());
         $this->assertEquals(new Hsla('300,100,50,1.0'), $rgb->toHsla());
         $this->assertEquals(new Hsv('300,100,100'), $rgb->toHsv());

--- a/tests/Color/RgbaTest.php
+++ b/tests/Color/RgbaTest.php
@@ -3,6 +3,7 @@
 namespace OzdemirBurak\Iris\Tests\Color;
 
 use OzdemirBurak\Iris\Color\Hex;
+use OzdemirBurak\Iris\Color\Hexa;
 use OzdemirBurak\Iris\Color\Hsl;
 use OzdemirBurak\Iris\Color\Hsla;
 use OzdemirBurak\Iris\Color\Hsv;
@@ -62,6 +63,7 @@ class RgbaTest extends TestCase
     {
         $rgba = new Rgba('rgba(11,22,33,0.2)');
         $this->assertEquals(new Hex('ced0d2'), $rgba->toHex());
+        $this->assertEquals(new Hexa('ced0d233'), $rgba->toHexa());
         $rgba = new Rgba('rgba(93,111,222,0.33)');
         $this->assertEquals(new Hex('a7add1'), $rgba->background((new Hex('ccc'))->toRgb())->toHex());
     }
@@ -78,6 +80,7 @@ class RgbaTest extends TestCase
         $this->assertEquals([255, 0, 255, 1.0], $rgba->values());
         $this->assertEquals('rgba(255,0,255,1)', $rgba->toRgba()->__toString());
         $this->assertEquals(new Hex('ff00ff'), $rgba->toHex());
+        $this->assertEquals(new Hexa('ff00ffff'), $rgba->toHexa());
         $this->assertEquals(new Hsl('300,100,50'), $rgba->toHsl());
         $this->assertEquals(new Hsla('300,100,50,1.0'), $rgba->toHsla());
         $this->assertEquals(new Hsv('300,100,100'), $rgba->toHsv());


### PR DESCRIPTION
Fixes #28 

The new `Hexa` class initialisation can take either a standard hex color value (defaults to opacity of 1) or an eight-digit string.  Internally, the alpha value is stored as a float to make it more compatible with the other color classes, but when represented as a string it'll be converted back to a hax value.

Notable changes:

* New Hexa class added with tests
* Factory changed as it can't just assume something starting with `#` is the Hex class
* Other color class types updated to add `toHexa` method
* Test for other color types updated to test the `toHexa` methods

![image](https://user-images.githubusercontent.com/684421/135773924-a8da0469-b1f0-42d8-ab63-f849751030fa.png)
