### PR TITLE
Add BaseColor::mixInHsv()

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,18 @@ $hex = new Hex('#000');
 echo $hex->mix(new Hex('#fff'), 50); // #808080
 ```
 
+#### Mix in HSV space
+
+Same as mix(), but interpolation is done in HSV space rather than in
+RGB space. The result may be closer to what the human eye perceives as
+"the color in between".
+
+``` php
+$hex = new Hex('#ff000');
+echo $hex->mixInHsv(new Hex('#00ff00'), 50); // ##ffff00
+                                             // mix() would return #808000
+```
+
 #### Tint
 
 Mix color with white by a percent.

--- a/src/BaseColor.php
+++ b/src/BaseColor.php
@@ -198,6 +198,11 @@ abstract class BaseColor
      * @param \OzdemirBurak\Iris\BaseColor $color
      * @param int                          $percent
      *
+     * Do a linear interpolation between the two colors in HSV space. Given
+     * that the hue component is circular, there are two possible solutions;
+     * the algorithm chooses the solution on the shorter arc and normalizes
+     * the resulting hue to a value between 0 and 360.
+     *
      * @return mixed
      */
     public function mixInHsv(BaseColor $color, $percent = 50)

--- a/src/BaseColor.php
+++ b/src/BaseColor.php
@@ -195,6 +195,42 @@ abstract class BaseColor
     }
 
     /**
+     * @param \OzdemirBurak\Iris\BaseColor $color
+     * @param int                          $percent
+     *
+     * @return mixed
+     */
+    public function mixInHsv(BaseColor $color, $percent = 50)
+    {
+        $first = $this->toHsv();
+        $second = $color->toHsv();
+        $weight = $percent / 100;
+
+        $hue = $first->hue() * (1 - $weight) + $second->hue() * $weight;
+
+        // choose hue in the middle of the shortest way between first and second
+        if (abs($second->hue() - $first->hue()) > 180.) {
+            $hue += 180.;
+        }
+
+        // normalize hue
+        if ($hue >= 360.) {
+            $hue -= 360.;
+        }
+
+        $saturation = $first->saturation() * (1 - $weight)
+            + $second->saturation() * $weight;
+
+        $value = $first->value() * (1 - $weight) + $second->value() * $weight;
+
+        return $first
+            ->hue((int)($hue + .5))
+            ->saturation((int)($saturation + .5))
+            ->value((int)($value + .5))
+            ->back($this);
+    }
+
+    /**
      * @link https://github.com/less/less.js/blob/master/packages/less/src/less/functions/color.js
      *
      * @param int $percent

--- a/tests/OperationsTest.php
+++ b/tests/OperationsTest.php
@@ -5,6 +5,7 @@ namespace OzdemirBurak\Iris\Tests;
 use OzdemirBurak\Iris\Color\Hex;
 use OzdemirBurak\Iris\Color\Hsl;
 use OzdemirBurak\Iris\Color\Hsla;
+use OzdemirBurak\Iris\Color\Hsv;
 use OzdemirBurak\Iris\Color\Rgb;
 use OzdemirBurak\Iris\Color\Rgba;
 use PHPUnit\Framework\TestCase;
@@ -49,6 +50,32 @@ class OperationsTest extends TestCase
     {
         $this->assertEquals(new Hex('#808080'), (new Hex('#000'))->mix(new Hex('#fff')));
         $this->assertEquals(new Hex('#ff8000'), (new Hex('#ff0000'))->mix(new Hex('#ffff00')));
+    }
+
+    /**
+     * @group operations-mixInHsv
+     */
+    public function testMixInHsv()
+    {
+        $this->assertEquals(
+            new Hsv('275,20,40'),
+            (new Hsv('300,10,20'))->mixInHsv((new Hsv('200,50,100'))->toRgb(), 25)
+        );
+
+        $this->assertEquals(
+            (new Hsv('270,30,55'))->toRgba(),
+            (new Hsv('300,20,50'))->toRgba()->mixInHsv(new Hsv('240,40,60'))
+        );
+
+        $this->assertEquals(
+            new Hsv('345,60,25'),
+            (new Hsv('0,100,50'))->mixInHsv(new Hsv('330,20,0'))
+        );
+
+        $this->assertEquals(
+            new Hsv('20,25,40'),
+            (new Hsv('100,0,50'))->mixInHsv(new Hsv('300,50,30'))
+        );
     }
 
     /**


### PR DESCRIPTION
Has the same interface as BaseColor::mix(), but interpolation is done in HSV space rather than in RGB space. The result may be closer to what the human eye perceives as "the color in between".