### PR TITLE
Use a non-locale aware output

### DIFF
--- a/src/Traits/AlphaTrait.php
+++ b/src/Traits/AlphaTrait.php
@@ -52,7 +52,7 @@ trait AlphaTrait
      */
     protected function alphaHexToFloat(string $alpha): float
     {
-        return sprintf('%0.2f', hexdec($alpha) / 255);
+        return sprintf('%0.2F', hexdec($alpha) / 255);
     }
 
     /**


### PR DESCRIPTION
Otherwise, the alpha value will not be handled correctly i.e. in a German locale (this locale uses a comma instead of a dot).