### PR TITLE
Php73

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^8.0"
+        "php": "^7.3|^8.0"
     },
     "require-dev": {
         "phpunit/phpunit" : "~8.0|~9.0",

--- a/src/BaseColor.php
+++ b/src/BaseColor.php
@@ -11,7 +11,7 @@ abstract class BaseColor
      *
      * @return bool|string
      */
-    abstract protected function validate(string $code): bool|string;
+    abstract protected function validate(string $code);
 
     /**
      * @param string $color

--- a/src/Color/Hex.php
+++ b/src/Color/Hex.php
@@ -15,7 +15,7 @@ class Hex extends BaseColor
      *
      * @return string|bool
      */
-    protected function validate(string $code): bool|string
+    protected function validate(string $code)
     {
         $color = str_replace('#', '', DefinedColor::find($code));
         if (strlen($color) === 3) {

--- a/src/Color/Hexa.php
+++ b/src/Color/Hexa.php
@@ -16,7 +16,7 @@ class Hexa extends BaseColor
      *
      * @return string|bool
      */
-    protected function validate(string $code): bool|string
+    protected function validate(string $code)
     {
         $color = str_replace('#', '', DefinedColor::find($code));
         return preg_match('/^[a-f0-9]{6}([a-f0-9]{2})?$/i', $color) ? $color : false;

--- a/src/Color/Hsla.php
+++ b/src/Color/Hsla.php
@@ -16,7 +16,7 @@ class Hsla extends BaseColor
      *
      * @return false|string
      */
-    protected function validate(string $code): bool|string
+    protected function validate(string $code)
     {
         [$class, $index] = property_exists($this, 'lightness') ? ['hsl', 2] : ['hsv', 3];
         $color = str_replace(["{$class}a", '(', ')', ' ', '%'], '', DefinedColor::find($code, $index));

--- a/src/Color/Hsv.php
+++ b/src/Color/Hsv.php
@@ -12,7 +12,7 @@ class Hsv extends BaseColor
     /**
      * @var int
      */
-    protected int $value;
+    protected $value;
 
     /**
      * @param string $color
@@ -141,7 +141,7 @@ class Hsv extends BaseColor
      *
      * @return int|$this
      */
-    public function value($value = null): int|static
+    public function value($value = null)
     {
         if (is_numeric($value)) {
             $this->value = $value >= 0 && $value <= 100 ? $value : $this->value;

--- a/src/Color/Rgb.php
+++ b/src/Color/Rgb.php
@@ -13,14 +13,14 @@ class Rgb extends BaseColor
     /**
      * @var bool
      */
-    protected bool $castsInteger = true;
+    protected $castsInteger = true;
 
     /**
      * @param string $code
      *
      * @return string|bool
      */
-    protected function validate(string $code): bool|string
+    protected function validate(string $code)
     {
         $color = str_replace(['rgb', '(', ')', ' '], '', DefinedColor::find($code, 1));
         if (preg_match('/^(\d{1,3}),(\d{1,3}),(\d{1,3})$/', $color, $matches)) {
@@ -140,12 +140,20 @@ class Rgb extends BaseColor
      */
     private function getH($max, $r, $g, $b, $d): float
     {
-        $h = match ($max) {
-            $r => ($g - $b) / $d + ($g < $b ? 6 : 0),
-            $g => ($b - $r) / $d + 2,
-            $b => ($r - $g) / $d + 4,
-            default => $max,
-        };
+        switch ($max) {
+            case $r:
+                $h = ($g - $b) / $d + ($g < $b ? 6 : 0);
+                break;
+            case $g:
+                $h = ($b - $r) / $d + 2;
+                break;
+            case $b:
+                $h = ($r - $g) / $d + 4;
+                break;
+            default:
+                $h = $max;
+                break;
+        }
         return $h / 6;
     }
 

--- a/src/Color/Rgba.php
+++ b/src/Color/Rgba.php
@@ -21,7 +21,7 @@ class Rgba extends BaseColor
      *
      * @return bool|string
      */
-    protected function validate(string $code): bool|string
+    protected function validate(string $code)
     {
         $color = str_replace(['rgba', '(', ')', ' '], '', DefinedColor::find($code, 1));
         if (substr_count($color, ',') === 2) {
@@ -143,7 +143,7 @@ class Rgba extends BaseColor
      *
      * @return $this
      */
-    public function background(Rgb $rgb): static
+    public function background(Rgb $rgb): self
     {
         $this->background = $rgb;
         return $this;

--- a/src/Traits/AlphaTrait.php
+++ b/src/Traits/AlphaTrait.php
@@ -14,7 +14,7 @@ trait AlphaTrait
      *
      * @return $this|float
      */
-    public function alpha($alpha = null): float|static
+    public function alpha($alpha = null)
     {
         if ($alpha !== null) {
             $this->alpha = min($alpha, 1);
@@ -38,9 +38,9 @@ trait AlphaTrait
      */
     protected function fixPrecision($color): string
     {
-        if (str_contains($color, ',')) {
+        if (strpos($color, ',') !== false) {
             $parts = explode(',', $color);
-            $parts[3] = !str_contains($parts[3], '.') ? $parts[3] . '.0' : $parts[3];
+            $parts[3] = strpos($parts[3], '.') === false ? $parts[3] . '.0' : $parts[3];
             $color = implode(',', $parts);
         }
         return $color;

--- a/src/Traits/HsTrait.php
+++ b/src/Traits/HsTrait.php
@@ -9,19 +9,19 @@ trait HsTrait
     /**
      * @var int
      */
-    protected int $hue;
+    protected $hue;
 
     /**
      * @var int
      */
-    protected int $saturation;
+    protected $saturation;
 
     /**
      * @param string $code
      *
      * @return string|bool
      */
-    protected function validate(string $code): bool|string
+    protected function validate(string $code)
     {
         [$class, $index] = property_exists($this, 'lightness') ? ['hsl', 2] : ['hsv', 3];
         $color = str_replace([$class, '(', ')', ' ', '%'], '', DefinedColor::find($code, $index));
@@ -39,7 +39,7 @@ trait HsTrait
      *
      * @return int|$this
      */
-    public function hue($hue = null): int|static
+    public function hue($hue = null)
     {
         if (is_numeric($hue)) {
             $this->hue = $hue >= 0 && $hue <= 360 ? $hue : $this->hue;
@@ -53,7 +53,7 @@ trait HsTrait
      *
      * @return int|$this
      */
-    public function saturation($saturation = null): int|static
+    public function saturation($saturation = null)
     {
         if (is_numeric($saturation)) {
             $this->saturation = $saturation >= 0 && $saturation <= 100 ? $saturation : $this->saturation;

--- a/src/Traits/HslTrait.php
+++ b/src/Traits/HslTrait.php
@@ -11,14 +11,14 @@ trait HslTrait
     /**
      * @var int
      */
-    protected int $lightness;
+    protected $lightness;
 
     /**
      * @param int|string $lightness
      *
      * @return int|$this
      */
-    public function lightness($lightness = null): int|static
+    public function lightness($lightness = null)
     {
         if (is_numeric($lightness)) {
             $this->lightness = $lightness >= 0 && $lightness <= 100 ? $lightness : $this->lightness;

--- a/src/Traits/RgbTrait.php
+++ b/src/Traits/RgbTrait.php
@@ -7,24 +7,24 @@ trait RgbTrait
     /**
      * @var string|int
      */
-    protected string|int $red;
+    protected $red;
 
     /**
      * @var string|int
      */
-    protected string|int $green;
+    protected $green;
 
     /**
      * @var string|int
      */
-    protected string|int $blue;
+    protected $blue;
 
     /**
      * @param int|string $red
      *
      * @return int|string|$this
      */
-    public function red($red = null): int|string|static
+    public function red($red = null)
     {
         if ($red !== null) {
             $this->validateAndSet('red', $red);
@@ -38,7 +38,7 @@ trait RgbTrait
      *
      * @return float|int|string|$this
      */
-    public function green($green = null): float|int|string|static
+    public function green($green = null)
     {
         if ($green !== null) {
             $this->validateAndSet('green', $green);
@@ -52,7 +52,7 @@ trait RgbTrait
      *
      * @return float|int|string|$this
      */
-    public function blue($blue = null): float|int|string|static
+    public function blue($blue = null)
     {
         if ($blue !== null) {
             $this->validateAndSet('blue', $blue);
@@ -77,7 +77,7 @@ trait RgbTrait
      * @param string           $property
      * @param float|int|string $value
      */
-    protected function validateAndSet(string $property, float|int|string $value): void
+    protected function validateAndSet(string $property, $value): void
     {
         if (!empty($this->castsInteger)) {
             $this->{$property} = $value >= 0 && $value <= 255 ? (int) round($value) : $this->{$property};


### PR DESCRIPTION
I'm afraid I'm limited to PHP 7.3 because I need to work with Cygwin, so the switch to exclusive PHP 8 support makes this extension unusable for me. Therefore I suggest to do without the constructs that require PHP 7.4 or PHP 8. There are actually not many of them:
* type declarations on class properties
* union type declarations, mainly used in return type hints and in a few cases in argument type hints
* the function str_contains()
* the switch shorthand used in Rgb::getH()

The last two points are just a question of elegance. The first two make indeed a difference when functions are called with parameters of the wrong type, so I perfectly understand that they are useful. But personally I'd very much appreciate if I could continue using this extension (without being forced to maintain a personal fork).