### PR TITLE
fix: use float instead of int to avoid warnings #2

### DIFF
--- a/src/Traits/HsTrait.php
+++ b/src/Traits/HsTrait.php
@@ -79,7 +79,7 @@ trait HsTrait
      *
      * @return array
      */
-    public function valuesInUnitFloaterval(): array
+    public function valuesInUnitInterval(): array
     {
         return [
             $this->hue() / 360,

--- a/src/Traits/HsTrait.php
+++ b/src/Traits/HsTrait.php
@@ -7,14 +7,14 @@ use OzdemirBurak\Iris\Helpers\DefinedColor;
 trait HsTrait
 {
     /**
-     * @var int
+     * @var float
      */
-    protected int $hue;
+    protected float $hue;
 
     /**
-     * @var int
+     * @var float
      */
-    protected int $saturation;
+    protected float $saturation;
 
     /**
      * @param string $code
@@ -35,31 +35,31 @@ trait HsTrait
     }
 
     /**
-     * @param int|string $hue
+     * @param float|string $hue
      *
-     * @return int|$this
+     * @return float|$this
      */
-    public function hue($hue = null): int|static
+    public function hue($hue = null): float|static
     {
         if (is_numeric($hue)) {
             $this->hue = $hue >= 0 && $hue <= 360 ? $hue : $this->hue;
             return $this;
         }
-        return (int) $this->hue;
+        return (float) $this->hue;
     }
 
     /**
-     * @param int|string $saturation
+     * @param float|string $saturation
      *
-     * @return int|$this
+     * @return float|$this
      */
-    public function saturation($saturation = null): int|static
+    public function saturation($saturation = null): float|static
     {
         if (is_numeric($saturation)) {
             $this->saturation = $saturation >= 0 && $saturation <= 100 ? $saturation : $this->saturation;
             return $this;
         }
-        return (int) $this->saturation;
+        return (float) $this->saturation;
     }
 
     /**
@@ -79,7 +79,7 @@ trait HsTrait
      *
      * @return array
      */
-    public function valuesInUnitInterval(): array
+    public function valuesInUnitFloaterval(): array
     {
         return [
             $this->hue() / 360,

--- a/src/Traits/HslTrait.php
+++ b/src/Traits/HslTrait.php
@@ -9,22 +9,22 @@ trait HslTrait
     use HsTrait;
 
     /**
-     * @var int
+     * @var float
      */
-    protected int $lightness;
+    protected float $lightness;
 
     /**
-     * @param int|string $lightness
+     * @param float|string $lightness
      *
-     * @return int|$this
+     * @return float|$this
      */
-    public function lightness($lightness = null): int|static
+    public function lightness($lightness = null): float|static
     {
         if (is_numeric($lightness)) {
             $this->lightness = $lightness >= 0 && $lightness <= 100 ? $lightness : $this->lightness;
             return $this;
         }
-        return (int) $this->lightness;
+        return (float) $this->lightness;
     }
 
     /**


### PR DESCRIPTION
It seems that there were still a few warnings and not everything was fixed by https://github.com/ozdemirburak/iris/pull/40

@ozdemirburak could you please have another look? Thanks!