### PR TITLE
[PHP 7] feat: safe alpha trait

### DIFF
--- a/src/Traits/AlphaTrait.php
+++ b/src/Traits/AlphaTrait.php
@@ -24,7 +24,7 @@ trait AlphaTrait
     }
 
     /**
-     * @param null $alpha
+     * @param float $alpha
      *
      * @return $this|float
      */
@@ -32,7 +32,7 @@ trait AlphaTrait
     {
         setlocale(LC_NUMERIC, 'C');
 
-        $safeAlpha = $alpha;
+        $safeAlpha = round($alpha, 2);
 
         setlocale(LC_NUMERIC, 0);
 

--- a/src/Traits/AlphaTrait.php
+++ b/src/Traits/AlphaTrait.php
@@ -17,10 +17,26 @@ trait AlphaTrait
     public function alpha($alpha = null)
     {
         if ($alpha !== null) {
-            $this->alpha = min($alpha, 1);
+            $this->alpha = $this->localeSafeAlpha(min($alpha, 1));
             return $this;
         }
-        return $this->alpha;
+        return $this->localeSafeAlpha($this->alpha);
+    }
+
+    /**
+     * @param null $alpha
+     *
+     * @return $this|float
+     */
+    public function localeSafeAlpha($alpha)
+    {
+        setlocale(LC_NUMERIC, 'C');
+
+        $safeAlpha = $alpha;
+
+        setlocale(LC_NUMERIC, 0);
+
+        return $safeAlpha;
     }
 
     /**


### PR DESCRIPTION
This PR adds feature to safely get alpha channel on PHP 7, regardless of machine's locale.
Fixes #38.