### PR TITLE
fix: rgba to hlsa and hexa

### DIFF
--- a/src/Color/Hsla.php
+++ b/src/Color/Hsla.php
@@ -112,7 +112,14 @@ class Hsla extends BaseColor
      */
     public function toHexa(): Hexa
     {
-        return $this->toHex()->toHexa()->alpha($this->alpha());
+        $old_alpha = $this->alpha();
+
+        return $this
+            ->clone()
+            ->alpha(1)
+            ->toHex()
+            ->toHexa()
+            ->alpha($old_alpha);
     }
 
     /**

--- a/src/Color/Rgba.php
+++ b/src/Color/Rgba.php
@@ -100,7 +100,14 @@ class Rgba extends BaseColor
      */
     public function toHexa(): Hexa
     {
-        return $this->toRgb()->toHex()->toHexa()->alpha($this->alpha());
+        $old_alpha = $this->alpha();
+
+        return $this
+            ->clone()
+            ->alpha(1)
+            ->toRgb()
+            ->toHexa()
+            ->alpha($old_alpha);
     }
 
     /**
@@ -118,7 +125,14 @@ class Rgba extends BaseColor
      */
     public function toHsla(): Hsla
     {
-        return $this->toHsl()->toHsla()->alpha($this->alpha());
+        $old_alpha = $this->alpha();
+
+        return $this
+            ->clone()
+            ->alpha(1)
+            ->toHsl()
+            ->toHsla()
+            ->alpha($old_alpha);
     }
 
     /**

--- a/src/Traits/AlphaTrait.php
+++ b/src/Traits/AlphaTrait.php
@@ -61,6 +61,6 @@ trait AlphaTrait
      */
     protected function alphaFloatToHex(float $alpha): string
     {
-        return dechex($alpha * 255);
+        return dechex(intval($alpha * 255));
     }
 }

--- a/tests/Color/HslaTest.php
+++ b/tests/Color/HslaTest.php
@@ -80,7 +80,7 @@ class HslaTest extends TestCase
         $hsla = new Hsla('hsla(150,100%,50%,0.3)');
         $this->assertEquals(new Hex('b2ffd8'), $hsla->toHex());
         $this->assertEquals(new Rgba('0,255,128,0.3'), $hsla->toRgba());
-        $this->assertEquals(new Hexa('b2ffd84c'), $hsla->toHexa());
+        $this->assertEquals(new Hexa('00ff804c'), $hsla->toHexa());
     }
 
 

--- a/tests/Color/RgbaTest.php
+++ b/tests/Color/RgbaTest.php
@@ -63,7 +63,7 @@ class RgbaTest extends TestCase
     {
         $rgba = new Rgba('rgba(11,22,33,0.2)');
         $this->assertEquals(new Hex('ced0d2'), $rgba->toHex());
-        $this->assertEquals(new Hexa('ced0d233'), $rgba->toHexa());
+        $this->assertEquals(new Hexa('0b162133'), $rgba->toHexa());
         $rgba = new Rgba('rgba(93,111,222,0.33)');
         $this->assertEquals(new Hex('a7add1'), $rgba->background((new Hex('ccc'))->toRgb())->toHex());
     }


### PR DESCRIPTION
This PR fixes #37, where `\Color\Rgba` incorrectly converts to `hlsa` and `hexa`.

Technically, `toHexa()` and `toHlsa()` method will save the current alpha channel using into `$old_alpha`, clone the current color profile, convert to either `hlsa` or `hexa`, then re-apply the alpha channel using the `$old_alpha`.

Also, in PHP 8.1, `alphaFloatToHex()` will return a deprecation warning because implicit float to integer conversion is deprecated, please check this [article](https://php.watch/versions/8.1/deprecate-implicit-conversion-incompatible-float-string) to verify.

I also changed the test a little bit to comply the new `toHexa` value.