### PR TITLE
Fix incorrect @param type

### DIFF
--- a/src/Traits/AlphaTrait.php
+++ b/src/Traits/AlphaTrait.php
@@ -10,7 +10,7 @@ trait AlphaTrait
     protected $alpha;
 
     /**
-     * @param null $alpha
+     * @param $alpha
      *
      * @return $this|float
      */


### PR DESCRIPTION
$alpha can be other values than `null`. 

Right now PHPStan returns this error: 
```
  - '#Parameter \#1 \$alpha of method OzdemirBurak\\Iris\\Color\\Rgba\:\:alpha\(\) expects null, float given#'
  🪪 argument.type
```

This should be fixed by this PR.